### PR TITLE
fix(email): Mailgun env vars robustas en Railway

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,19 @@ Variables esenciales:
 - `MONGO_URI` - Conexión a MongoDB (mongodb+srv://...)
 - `JWT_SECRET` - Secreto para firmar JWT tokens
 - `GOOGLE_CLIENT_ID` - ID de cliente de Google OAuth (para mobile)
+- `MAILGUN_API_KEY` - API key de Mailgun para envío de correos transaccionales
+- `MAILGUN_DOMAIN` - Dominio verificado en Mailgun (ej. mg.tu-dominio.com)
+
+#### Mailgun en Railway (nota importante)
+- El servicio de correo usa inicialización dinámica de variables de entorno en tiempo de envío.
+- Esto evita que `MAILGUN_API_KEY` y `MAILGUN_DOMAIN` queden en `undefined` cuando Railway inyecta variables después de cargar módulos.
+- Si faltan variables, el sistema entra en modo demo (logs en consola) sin romper el flujo de registro/reset.
+
+**Checklist rápido en Railway:**
+1. Verifica que existan `MAILGUN_API_KEY` y `MAILGUN_DOMAIN` en Variables.
+2. Confirma redeploy/restart del servicio tras actualizar variables.
+3. Prueba registro o reenvío de código y revisa logs.
+4. Debe aparecer `✅ Mailgun configurado correctamente` y no el warning de variables faltantes.
 
 #### Exchange Rate API (Configuración recomendada)
 - `EXCHANGE_RATE_API_KEY` - API key de exchangerate-api.com

--- a/services/emailService.js
+++ b/services/emailService.js
@@ -1,29 +1,69 @@
 const mailgun = require('mailgun.js');
 const FormData = require('form-data');
 
-// Inicializar cliente de Mailgun con API Key (si está disponible)
+// Inicializar helper de Mailgun
 const mg = new mailgun(FormData);
-const domain = process.env.MAILGUN_DOMAIN;
-const apiKey = process.env.MAILGUN_API_KEY;
 
 // Flag para saber si Mailgun está configurado
 let mailgunConfigured = false;
 let client = null;
+let lastConfigKey = null;
+let warnedMissingConfig = false;
 
-if (apiKey && domain) {
+const getEnvValue = (name) => {
+    const raw = process.env[name];
+    if (typeof raw !== 'string') {
+        return '';
+    }
+    const trimmed = raw.trim();
+    return trimmed.replace(/^['"]|['"]$/g, '');
+};
+
+const resolveMailgunConfig = () => {
+    const apiKey = getEnvValue('MAILGUN_API_KEY') || getEnvValue('MAILGUN_KEY');
+    const domain = getEnvValue('MAILGUN_DOMAIN');
+    return { apiKey, domain };
+};
+
+const ensureMailgunClient = () => {
+    const { apiKey, domain } = resolveMailgunConfig();
+    const configKey = `${apiKey}::${domain}`;
+
+    if (!apiKey || !domain) {
+        mailgunConfigured = false;
+        client = null;
+        lastConfigKey = null;
+
+        if (!warnedMissingConfig) {
+            console.warn('⚠️  MAILGUN_API_KEY/MAILGUN_DOMAIN no configurados. Emails se loguearán en consola.');
+            warnedMissingConfig = true;
+        }
+
+        return { configured: false, domain: '' };
+    }
+
+    if (client && mailgunConfigured && lastConfigKey === configKey) {
+        return { configured: true, domain };
+    }
+
     try {
-        client = mg.client({ 
-            username: 'api', 
-            key: apiKey 
+        client = mg.client({
+            username: 'api',
+            key: apiKey
         });
         mailgunConfigured = true;
+        lastConfigKey = configKey;
+        warnedMissingConfig = false;
         console.log('✅ Mailgun configurado correctamente');
+        return { configured: true, domain };
     } catch (err) {
+        mailgunConfigured = false;
+        client = null;
+        lastConfigKey = null;
         console.warn('⚠️  Mailgun no disponible:', err.message);
+        return { configured: false, domain: '' };
     }
-} else {
-    console.warn('⚠️  MAILGUN_API_KEY o MAILGUN_DOMAIN no configurados. Emails se loguearán en consola.');
-}
+};
 
 /**
  * Envía un correo con el código de verificación.
@@ -32,21 +72,23 @@ if (apiKey && domain) {
  */
 const sendVerificationEmail = async (email, code) => {
     try {
+        const mailgunState = ensureMailgunClient();
+
         // Si Mailgun no está configurado, loguear en consola
-        if (!mailgunConfigured) {
+        if (!mailgunState.configured) {
             console.log(`📧 [MODO DEMO] Código de verificación para ${email}: ${code} (Expira en 5 minutos)`);
             return;
         }
 
         const mailOptions = {
-            from: `"Divisando" <noreply@${domain}>`,
+            from: `"Divisando" <noreply@${mailgunState.domain}>`,
             to: email,
             subject: 'Código de Verificación',
             text: `Tu código de verificación es: ${code}. Expira en 5 minutos.`,
             html: `<p>Tu código de verificación es: <strong>${code}</strong></p><p>Expira en 5 minutos.</p>`
         };
 
-        await client.messages.create(domain, mailOptions);
+        await client.messages.create(mailgunState.domain, mailOptions);
         console.log(`📧 Código de verificación enviado a ${email}`);
     } catch (error) {
         console.error(`❌ Error al enviar correo: ${error.message}`);
@@ -61,14 +103,16 @@ const sendVerificationEmail = async (email, code) => {
  */
 const sendPasswordChangedEmail = async (email, username) => {
     try {
+        const mailgunState = ensureMailgunClient();
+
         // Si Mailgun no está configurado, loguear en consola
-        if (!mailgunConfigured) {
+        if (!mailgunState.configured) {
             console.log(`📧 [MODO DEMO] Notificación de cambio de contraseña enviada a ${email}`);
             return;
         }
 
         const mailOptions = {
-            from: `"Divisando" <noreply@${domain}>`,
+            from: `"Divisando" <noreply@${mailgunState.domain}>`,
             to: email,
             subject: '🔐 Contraseña Restablecida Exitosamente',
             text: `Hola ${username},\n\nTu contraseña ha sido restablecida exitosamente.\n\nSi no realizaste este cambio, contacta inmediatamente a soporte.\n\nSaludos,\nEquipo Divisando`,
@@ -93,7 +137,7 @@ const sendPasswordChangedEmail = async (email, username) => {
             `
         };
 
-        await client.messages.create(domain, mailOptions);
+        await client.messages.create(mailgunState.domain, mailOptions);
         console.log(`📧 Confirmación de cambio de contraseña enviada a ${email}`);
     } catch (error) {
         console.error(`❌ Error al enviar correo de confirmación: ${error.message}`);


### PR DESCRIPTION
## Contexto
Se corrige una incidencia en el envío de correos donde `MAILGUN_API_KEY` y `MAILGUN_DOMAIN` podían quedar como `undefined` en runtime (especialmente visible en Railway), provocando fallback a modo demo.

## Qué resolví
- Refactor en `services/emailService.js` para inicialización lazy/dinámica de Mailgun.
- Lectura de variables en tiempo de envío en lugar de leerlas solo al cargar módulo.
- Normalización de env vars (trim y limpieza de comillas).
- Soporte fallback para `MAILGUN_KEY` además de `MAILGUN_API_KEY`.
- Reconfiguración automática del cliente si cambian credenciales.
- Reducción de ruido en logs (warning de variables faltantes solo cuando aplica).
- Documentación agregada en `README.md` con checklist rápido de validación en Railway.

## Validación
- Carga del módulo validada sin errores en runtime.
- Se verificó que `emailService.js` no tenga errores de análisis estático en el editor.
- Rama publicada con commit: `7565958`.

## Siguiente paso recomendado (rápido)
1. Hacer deploy/restart en Railway con este PR.
2. Ejecutar flujo de registro/reenvío de código.
3. Confirmar en logs: `✅ Mailgun configurado correctamente`.
4. Verificar que no aparezca warning de `MAILGUN_API_KEY/MAILGUN_DOMAIN` faltantes.

## Archivos modificados
- `services/emailService.js`
- `README.md`
