### PR TITLE
fix(auth): robust Google audience check (aud/azp)

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -11,7 +11,10 @@ const getGoogleAudiences = () => {
         process.env.GOOGLE_WEB_CLIENT_ID,
         process.env.GOOGLE_ANDROID_CLIENT_ID,
         process.env.GOOGLE_IOS_CLIENT_ID,
-    ].filter(Boolean);
+    ]
+        .filter(Boolean)
+        .map((value) => value.trim())
+        .filter(Boolean);
 
     const fromList = (process.env.GOOGLE_CLIENT_IDS || '')
         .split(',')
@@ -218,14 +221,28 @@ const loginWithGoogle = async (req, res, next) => {
             return res.status(500).json({ error: 'Configuración Google incompleta en servidor.' });
         }
 
-        // Verificar el idToken con Google
+        // Verificar firma/issuer/expiración del idToken con Google
         const client = new OAuth2Client(googleAudiences[0]);
         const ticket = await client.verifyIdToken({
             idToken,
-            audience: googleAudiences,
         });
         
         const payload = ticket.getPayload();
+        const tokenAudience = (payload?.aud || '').trim();
+        const tokenAuthorizedParty = (payload?.azp || '').trim();
+
+        const audienceMatches = googleAudiences.includes(tokenAudience);
+        const azpMatches = tokenAuthorizedParty ? googleAudiences.includes(tokenAuthorizedParty) : false;
+
+        if (!audienceMatches && !azpMatches) {
+            apiLogger.error('Error en loginWithGoogle: Wrong recipient, payload audience != requiredAudience', {
+                tokenAudience,
+                tokenAuthorizedParty,
+                configuredAudiences: googleAudiences,
+            });
+            return res.status(401).json({ error: 'Token de Google inválido.' });
+        }
+
         const { sub: googleId, email, name } = payload;
 
         // Buscar o crear usuario


### PR DESCRIPTION
## Summary
- addresses Railway log: Wrong recipient, payload audience != requiredAudience
- verifies Google idToken signature/issuer/expiry first
- validates token ud and zp against configured allowed audiences
- normalizes env audience values (trim) to avoid whitespace mismatch\

## Why
Some valid Google tokens can fail strict recipient checks when client IDs are configured with formatting issues or when authorized party (zp) differs from ud in multi-client setups.

## Validation
- node --check controllers/authController.js\

## Required Railway envs
- GOOGLE_CLIENT_ID
- GOOGLE_WEB_CLIENT_ID
- GOOGLE_ANDROID_CLIENT_ID
- optional: GOOGLE_IOS_CLIENT_ID
- optional: GOOGLE_CLIENT_IDS (csv)