### PR TITLE
fix(auth): normalize quoted Google env audiences

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -5,6 +5,16 @@ const { sendVerificationEmail, sendPasswordChangedEmail } = require('@services/e
 const { apiLogger } = require('@utils/logger');
 const { OAuth2Client } = require('google-auth-library');
 
+const normalizeEnvValue = (value) => {
+    if (!value) return '';
+
+    return value
+        .trim()
+        .replace(/^"|"$/g, '')
+        .replace(/^'|'$/g, '')
+        .trim();
+};
+
 const getGoogleAudiences = () => {
     const direct = [
         process.env.GOOGLE_CLIENT_ID,
@@ -13,12 +23,12 @@ const getGoogleAudiences = () => {
         process.env.GOOGLE_IOS_CLIENT_ID,
     ]
         .filter(Boolean)
-        .map((value) => value.trim())
+        .map((value) => normalizeEnvValue(value))
         .filter(Boolean);
 
     const fromList = (process.env.GOOGLE_CLIENT_IDS || '')
         .split(',')
-        .map((value) => value.trim())
+        .map((value) => normalizeEnvValue(value))
         .filter(Boolean);
 
     return [...new Set([...direct, ...fromList])];


### PR DESCRIPTION
## Summary
- normalizes Google audience env values by trimming and stripping wrapping quotes
- prevents false audience mismatch when Railway values are saved as quoted strings

## Why
Railway env exports often appear quoted; strict string comparison can fail (ud/zp vs configured values) even when IDs are correct.

## Validation
- node --check controllers/authController.js

## Notes
Still recommended to store env values in Railway without wrapping quotes.