### PR TITLE
fix(startup): cargar module-alias antes de imports alias

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('module-alias/register');
 const http = require("http");
 const { connectDB, closeDB } = require("@config/database");
 const { scheduleExchangeRates, stopExchangeRates } = require("@tasks/fetchExchangeRates");


### PR DESCRIPTION
## Resumen\n- agrega equire('module-alias/register') al inicio de server.js\n- corrige error local/runtime: Cannot find module '@config/database'\n\n## Alcance\n- cambio mínimo de arranque\n- sin cambios en 	ests/\n- sin cambios en referencias de paquetes